### PR TITLE
Added proxy-server option

### DIFF
--- a/RMextract/getIONEX.py
+++ b/RMextract/getIONEX.py
@@ -612,6 +612,7 @@ def get_urllib_IONEXfile(time="2012/03/23/02:20:10.01",
     if "None" not in proxy_server:
     	import socket
     	import socks
+	import urllib2
 	s = socks.socksocket()
 	if proxy_type=="socks4":
 		ProxyType = socks.SOCKS4

--- a/RMextract/getIONEX.py
+++ b/RMextract/getIONEX.py
@@ -554,6 +554,104 @@ def _get_IONEX_file(time="2012/03/23/02:20:10.01",
         ftp.quit()
         return nfilenames[0]
 
+def get_urllib_IONEXfile(time="2012/03/23/02:20:10.01",
+                    server="ftp://cddis.gsfc.nasa.gov/gnss/products/ionex/",
+                    prefix="codg",
+                    outpath='./',
+                    overwrite=False,
+                    backupserver="ftp://cddis.gsfc.nasa.gov/gnss/products/ionex/",
+		    proxy_server=None,
+		    proxy_type=None,
+		    proxy_port=None,
+		    proxy_user=None,
+		    proxy_pass=None):
+    """Get IONEX file with prefix from server for a given day
+
+    Downloads files with given prefix from the ftp server, unzips and stores
+    the data. Uses urllib2 instead of ftplib to have the option to use a ftp proxy server.
+
+    Proxy args are optional.
+
+    Args:
+	time (string or list) : date of the observation
+	server (string) : ftp server + path to the ionex directories
+	prefix (string) : prefix of the IONEX files (case insensitive)
+	outpath (string) : path where the data is stored
+	overwrite (bool) : Do (not) overwrite existing data
+	proxy_server (string): address of proxyserver, either url or ip address
+	proxy_type (string): socks4 or socks5
+	proxy_port (int): port of proxy server
+	proxy_user (string): username for proxyserver
+	proxy_pass (string): password for proxyserver
+    """
+    if outpath[-1] != "/":
+        outpath += "/"
+    if not os.path.isdir(outpath):
+        try:
+            os.makedirs(outpath)
+        except:
+            print("cannot create output dir for IONEXdata: %s",
+                          outpath)
+
+    try:
+        yy = time[2:4]
+        year = int(time[:4])
+        month = int(time[5:7])
+        day = int(time[8:10])
+    except:
+        year = time[0]
+        yy = year - 2000
+        month = time[1]
+        day = time[2]
+    mydate = datetime.date(year, month, day)
+    dayofyear = mydate.timetuple().tm_yday
+    tried_backup=False
+    serverfound=False
+    backupfound=False    
+    #If proxy url is given, enable proxy using pysocks
+    if "None" not in proxy_server:
+    	import socket
+    	import socks
+	s = socks.socksocket()
+	if proxy_type=="socks4":
+		ProxyType = socks.SOCKS4
+	if proxy_type=="socks5":
+		ProxyType = socks.SOCKS5
+	s.set_proxy(ProxyType, proxy_server, proxy_port, rdns=True, username=proxy_user, password=proxy_pass)
+
+    # Url of the primary server has the syntax "ftp://ftp.aiub.unibe.ch/CODE/YYYY/CODGDOY0.YYI.Z" where DOY is the day of the year, padded with leading zero if <100, and YY is the last two digits of year.
+    # Url of the backup server has the syntax "ftp://cddis.gsfc.nasa.gov/gnss/products/ionex/YYYY/DOY/codgDOY.YYi.Z where DOY is the day of the year, padded with leading zero if <100, and YY is the last two digits of year.
+    #try primary url
+
+    try:	
+	primary = urllib2.urlopen(server,timeout=30)
+	serverfound = True
+    except:
+	    try:	
+		secondary = urllib2.urlopen(backupserver,timeout=30)
+		backupfound = True
+	    except:
+		logging.error('Primary and Backup Server not responding') #enable in lover environment
+    if serverfound:
+    	url = "ftp://ftp.aiub.unibe.ch/CODE/%4d/%s%03d0.%02dI.Z"%(year,prefix.upper(),dayofyear,yy)
+    elif backupfound:
+    	url = "ftp://cddis.gsfc.nasa.gov/gnss/products/ionex/%4d/%03d/%s%03d0.%02di.Z"%(year,dayofyear,prefix,dayofyear,yy)
+
+    # Download IONEX file
+    fname = outpath+'/'+url.split('/')[-1]
+    site = urllib2.urlopen(url,timeout=30)
+    output=open(fname,'wb')
+    output.write(site.read())
+    output.close()
+    ###### gunzip files
+    command = "gunzip -dc %s > %s" % (fname, fname[:-2])
+    retcode = os.system(command)
+    if retcode:
+        raise RuntimeError("Could not run '%s'" % command)
+    else:
+    	os.remove(fname)
+    #returns filename of uncompressed file
+    return fname[:-2]
 
 def getIONEXfile(time="2012/03/23/02:20:10.01",
                  server="ftp://cddis.gsfc.nasa.gov/gnss/productsionex/",

--- a/RMextract/getRM.py
+++ b/RMextract/getRM.py
@@ -80,7 +80,15 @@ def getRM(MS=None,
                 stat_names =['st%d'%(i+1) for i in range(len(stat_pos))]
         if key=='useEMM':
             useEMM=kwargs[key]
-#      
+
+	if key=="proxy_server":		#Check to see if user wants to use a proxy for downloading IONEX files.
+	    use_proxy = True
+	    proxy_server=kwargs["proxy_server"]
+	    proxy_type=kwargs["proxy_type"]
+	    proxy_port=kwargs["proxy_port"]
+	    proxy_user=kwargs["proxy_user"]
+            proxy_pass=kwargs["proxy_pass"]
+      
     if timerange != 0:
       start_time = timerange[0]
       end_time = timerange[1]
@@ -150,7 +158,11 @@ def getRM(MS=None,
         dayofyear = date(date_parms[0],date_parms[1],date_parms[2]).timetuple().tm_yday  
         emm.date=date_parms[0]+float(dayofyear)/365.
         #get relevant ionex file
-        ionexf=ionex.getIONEXfile(time=date_parms,server=server,prefix=prefix,outpath=ionexPath)
+	if not use_proxy:
+	        ionexf=ionex.getIONEXfile(time=date_parms,server=server,prefix=prefix,outpath=ionexPath)
+	else:
+		ionexf=ionex.get_urllib_IONEXfile(time=date_parms,server=server,prefix=prefix,outpath=ionexPath,proxy_server=proxy_server,proxy_type=proxy_type,proxy_port=proxy_port,proxy_user=proxy_user,proxy_pass=proxy_pass)
+
         if ionexf==-1:
            print ("error opening ionex data")
            return


### PR DESCRIPTION
The new function uses urllib2 instead of ftplib. Also, PySocks needs to be installed in order to be able to add a proxy server for the ftp downloader.


I did not test it for "robr" files, since I don't know where to get them. Also I did not test the username/password options since I have no proxy which uses them.