### PR TITLE
Fix inconsistent indentation mixing tabs and spaces (causes crash in Py3)

### DIFF
--- a/RMextract/getIONEX.py
+++ b/RMextract/getIONEX.py
@@ -572,11 +572,11 @@ def get_urllib_IONEXfile(time="2012/03/23/02:20:10.01",
                     outpath='./',
                     overwrite=False,
                     backupserver="ftp://cddis.gsfc.nasa.gov/gnss/products/ionex/",
-		    proxy_server=None,
-		    proxy_type=None,
-		    proxy_port=None,
-		    proxy_user=None,
-		    proxy_pass=None):
+                    proxy_server=None,
+                    proxy_type=None,
+                    proxy_port=None,
+                    proxy_user=None,
+                    proxy_pass=None):
     """Get IONEX file with prefix from server for a given day
 
     Downloads files with given prefix from the ftp server, unzips and stores
@@ -585,16 +585,16 @@ def get_urllib_IONEXfile(time="2012/03/23/02:20:10.01",
     Proxy args are optional.
 
     Args:
-	time (string or list) : date of the observation
-	server (string) : ftp server + path to the ionex directories
-	prefix (string) : prefix of the IONEX files (case insensitive)
-	outpath (string) : path where the data is stored
-	overwrite (bool) : Do (not) overwrite existing data
-	proxy_server (string): address of proxyserver, either url or ip address
-	proxy_type (string): socks4 or socks5
-	proxy_port (int): port of proxy server
-	proxy_user (string): username for proxyserver
-	proxy_pass (string): password for proxyserver
+        time (string or list) : date of the observation
+        server (string) : ftp server + path to the ionex directories
+        prefix (string) : prefix of the IONEX files (case insensitive)
+        outpath (string) : path where the data is stored
+        overwrite (bool) : Do (not) overwrite existing data
+        proxy_server (string): address of proxyserver, either url or ip address
+        proxy_type (string): socks4 or socks5
+        proxy_port (int): port of proxy server
+        proxy_user (string): username for proxyserver
+        proxy_pass (string): password for proxyserver
     """
     prefix=prefix.upper()
     if outpath[-1] != "/":
@@ -632,33 +632,33 @@ def get_urllib_IONEXfile(time="2012/03/23/02:20:10.01",
     #If proxy url is given, enable proxy using pysocks
     import urllib2
     if proxy_server and ("None" not in proxy_server):
-    	import socket
-    	import socks
-	s = socks.socksocket()
-	if proxy_type=="socks4":
-		ProxyType = socks.SOCKS4
-	if proxy_type=="socks5":
-		ProxyType = socks.SOCKS5
-	s.set_proxy(ProxyType, proxy_server, proxy_port, rdns=True, username=proxy_user, password=proxy_pass)
+        import socket
+        import socks
+        s = socks.socksocket()
+        if proxy_type=="socks4":
+            ProxyType = socks.SOCKS4
+        if proxy_type=="socks5":
+            ProxyType = socks.SOCKS5
+        s.set_proxy(ProxyType, proxy_server, proxy_port, rdns=True, username=proxy_user, password=proxy_pass)
 
     # Url of the primary server has the syntax "ftp://ftp.aiub.unibe.ch/CODE/YYYY/CODGDOY0.YYI.Z" where DOY is the day of the year, padded with leading zero if <100, and YY is the last two digits of year.
     # Url of the backup server has the syntax "ftp://cddis.gsfc.nasa.gov/gnss/products/ionex/YYYY/DOY/codgDOY.YYi.Z where DOY is the day of the year, padded with leading zero if <100, and YY is the last two digits of year.
     #try primary url
 
-    try:	
-	primary = urllib2.urlopen(server,timeout=30)
-	serverfound = True
+    try:
+        primary = urllib2.urlopen(server,timeout=30)
+        serverfound = True
     except:
-	    try:	
-		secondary = urllib2.urlopen(backupserver,timeout=30)
-		backupfound = True
+            try:
+                secondary = urllib2.urlopen(backupserver,timeout=30)
+                backupfound = True
                 server=backupserver
-	    except:
-		logging.error('Primary and Backup Server not responding') #enable in lover environment
+            except:
+                logging.error('Primary and Backup Server not responding') #enable in lover environment
     if "ftp://ftp.aiub.unibe.ch" in server:
-    	url = "ftp://ftp.aiub.unibe.ch/CODE/%4d/%s%03d0.%02dI.Z"%(year,prefix.upper(),dayofyear,yy)
+        url = "ftp://ftp.aiub.unibe.ch/CODE/%4d/%s%03d0.%02dI.Z"%(year,prefix.upper(),dayofyear,yy)
     elif "ftp://cddis.gsfc.nasa.gov" in server:
-    	url = "ftp://cddis.gsfc.nasa.gov/gnss/products/ionex/%4d/%03d/%s%03d0.%02di.Z"%(year,dayofyear,prefix,dayofyear,yy)
+        url = "ftp://cddis.gsfc.nasa.gov/gnss/products/ionex/%4d/%03d/%s%03d0.%02di.Z"%(year,dayofyear,prefix,dayofyear,yy)
     elif "igsiono.uwm.edu.pl" in server:
         url = "https://igsiono.uwm.edu.pl/data/ilt/%4d/igrg%03d0.%02di"%(year,dayofyear,yy)
 

--- a/RMextract/getRM.py
+++ b/RMextract/getRM.py
@@ -81,12 +81,12 @@ def getRM(MS=None,
                 stat_names =['st%d'%(i+1) for i in range(len(stat_pos))]
         if key=='useEMM':
             useEMM=kwargs[key]
-	if key=="proxy_server":		#Check to see if user wants to use a proxy for downloading IONEX files.
-	    use_proxy = True
-	    proxy_server=kwargs["proxy_server"]
-	    proxy_type=kwargs["proxy_type"]
-	    proxy_port=kwargs["proxy_port"]
-	    proxy_user=kwargs["proxy_user"]
+        if key=="proxy_server":		#Check to see if user wants to use a proxy for downloading IONEX files.
+            use_proxy = True
+            proxy_server=kwargs["proxy_server"]
+            proxy_type=kwargs["proxy_type"]
+            proxy_port=kwargs["proxy_port"]
+            proxy_user=kwargs["proxy_user"]
             proxy_pass=kwargs["proxy_pass"]
       
     if timerange != 0:
@@ -158,13 +158,13 @@ def getRM(MS=None,
         dayofyear = date(date_parms[0],date_parms[1],date_parms[2]).timetuple().tm_yday  
         emm.date=date_parms[0]+float(dayofyear)/365.
         #get relevant ionex file
-	if not use_proxy:
+        if not use_proxy:
             if not "http" in server: #ftp server use ftplib
-	        ionexf=ionex.getIONEXfile(time=date_parms,server=server,prefix=prefix,outpath=ionexPath)
+                ionexf=ionex.getIONEXfile(time=date_parms,server=server,prefix=prefix,outpath=ionexPath)
             else:
                 ionexf=ionex.get_urllib_IONEXfile(time=date_parms,server=server,prefix=prefix,outpath=ionexPath)
-	else:
-		ionexf=ionex.get_urllib_IONEXfile(time=date_parms,server=server,prefix=prefix,outpath=ionexPath,proxy_server=proxy_server,proxy_type=proxy_type,proxy_port=proxy_port,proxy_user=proxy_user,proxy_pass=proxy_pass)
+        else:
+                ionexf=ionex.get_urllib_IONEXfile(time=date_parms,server=server,prefix=prefix,outpath=ionexPath,proxy_server=proxy_server,proxy_type=proxy_type,proxy_port=proxy_port,proxy_user=proxy_user,proxy_pass=proxy_pass)
 
         assert (ionexf!=-1),"error getting ionex data"
            


### PR DESCRIPTION
This should fix #30. Tabs have been converted to spaces and I confirmed that e.g. `from RMextract import getRM` no longer throws the error about an inconsistent mix tabs and spaces, fixing the crashing when run in a Python 3 environment.