### PR TITLE
Fix build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires = [
     "numpy",
     "scikit-build>=0.13",
     "setuptools",
+    "setuptools<65; python_version<'3.12'",
     "setuptools_scm",
     "wheel",
 ]


### PR DESCRIPTION
Latest `setuptools` breaks builds for older Python version. Constrain version of `setuptools` for Python < 3.12.